### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,13 +240,6 @@
 		<!-- Logging APIs -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-api</artifactId>
-			<version>1.6.1</version>
-			<type>jar</type>
-			<scope>compile</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
 			<version>1.6.1</version>
 			<type>jar</type>


### PR DESCRIPTION
removed slf4j-api. It is already included in slf4j-simple as dependency.
Moreoever, if I use a later version of slf4j-simple there is a conflict: 
![image](http://i.imgur.com/HaMS5LN.jpg)
