### PR TITLE
Support keywords [WIP]

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -84,20 +84,21 @@ class TestCaseService extends BaseService {
      * @param internalId
      * @param checkDuplicatedName
      * @param actionOnDuplicatedName
+     * @param keywords 
      * @return Test Case.
      * @throws TestLinkAPIException
      */
     protected TestCase createTestCase(String testCaseName, Integer testSuiteId, Integer testProjectId,
             String authorLogin, String summary, List<TestCaseStep> steps, String preconditions,
             TestImportance importance, ExecutionType execution, Integer order, Integer internalId,
-            Boolean checkDuplicatedName, ActionOnDuplicate actionOnDuplicatedName) throws TestLinkAPIException {
+            Boolean checkDuplicatedName, ActionOnDuplicate actionOnDuplicatedName, String keywords) throws TestLinkAPIException {
         TestCase testCase = null;
 
         Integer id = null;
 
         testCase = new TestCase(id, testCaseName, testSuiteId, testProjectId, authorLogin, summary, steps,
                 preconditions, importance, execution, null, order, internalId, null, checkDuplicatedName,
-                actionOnDuplicatedName, null, null, null, null, null, null, null);
+                actionOnDuplicatedName, null, null, null, null, null, null, null, keywords);
 
         try {
             Map<String, Object> executionData = Util.getTestCaseMap(testCase);

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -714,16 +714,17 @@ public class TestLinkAPI {
      * @param internalId
      * @param checkDuplicatedName
      * @param actionOnDuplicatedName
+     * @param keywords 
      * @return TestCase.
      * @throws TestLinkAPIException
      */
     public TestCase createTestCase(String testCaseName, Integer testSuiteId, Integer testProjectId, String authorLogin,
             String summary, List<TestCaseStep> steps, String preconditions, TestImportance importance,
             ExecutionType execution, Integer order, Integer internalId, Boolean checkDuplicatedName,
-            ActionOnDuplicate actionOnDuplicatedName) throws TestLinkAPIException {
+            ActionOnDuplicate actionOnDuplicatedName, String keywords) throws TestLinkAPIException {
         return this.testCaseService.createTestCase(testCaseName, testSuiteId, testProjectId, authorLogin, summary,
                 steps, preconditions, importance, execution, order, internalId, checkDuplicatedName,
-                actionOnDuplicatedName);
+                actionOnDuplicatedName, keywords);
     }
 
     /**

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/model/TestCase.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/model/TestCase.java
@@ -63,6 +63,7 @@ public class TestCase implements Serializable {
     private ExecutionStatus executionStatus;
     private Platform platform;
     private Integer featureId;
+    private String keywords;
 
     /**
 	 * 
@@ -99,13 +100,14 @@ public class TestCase implements Serializable {
      * @param executionStatus
      * @param plataform
      * @param featureId
+     * @param keywords
      */
     public TestCase(Integer id, String name, Integer testSuiteId, Integer testProjectId, String authorLogin,
             String summary, List<TestCaseStep> steps, String preconditions, TestImportance testImportance,
             ExecutionType executionType, Integer executionOrder, Integer order, Integer internalId,
             String fullExternalId, Boolean checkDuplicatedName, ActionOnDuplicate actionOnDuplicatedName,
             Integer versionId, Integer version, Integer parentId, List<CustomField> customFields,
-            ExecutionStatus executionStatus, Platform platform, Integer featureId) {
+            ExecutionStatus executionStatus, Platform platform, Integer featureId, String keywords) {
         super();
         this.id = id;
         this.name = name;
@@ -130,6 +132,7 @@ public class TestCase implements Serializable {
         this.executionStatus = executionStatus;
         this.platform = platform;
         this.featureId = featureId;
+        this.keywords = keywords;
     }
 
     /**
@@ -456,6 +459,14 @@ public class TestCase implements Serializable {
         this.featureId = featureId;
     }
 
+    public String getKeywards() {
+        return keywords;
+    }
+
+    public void setKeywords(String keywords) {
+        this.keywords = keywords;
+    }
+
     /*
      * (non-Javadoc)
      * 
@@ -470,7 +481,7 @@ public class TestCase implements Serializable {
                 + internalId + ", fullExternalId=" + fullExternalId + ", checkDuplicatedName=" + checkDuplicatedName
                 + ", actionOnDuplicatedName=" + actionOnDuplicatedName + ", versionId=" + versionId + ", version="
                 + version + ", parentId=" + parentId + ", customFields=" + customFields + ", executionStatus="
-                + executionStatus + ", platform=" + platform + ", featureId=" + featureId + "]";
+                + executionStatus + ", platform=" + platform + ", featureId=" + featureId + ", keywords=" + keywords + "]";
     }
 
 }

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/util/Util.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/util/Util.java
@@ -285,6 +285,7 @@ public final class Util {
         executionData.put(TestLinkParams.CHECK_DUPLICATED_NAME.toString(), testCase.getCheckDuplicatedName());
         executionData.put(TestLinkParams.ACTION_ON_DUPLICATED_NAME.toString(),
                 testCase.getActionOnDuplicatedName() != null ? testCase.getActionOnDuplicatedName().toString() : null);
+        executionData.put(TestLinkParams.KEYWORDS.toString(), testCase.getKeywards());
 
         return executionData;
     }

--- a/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestCreateTestCase.java
+++ b/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestCreateTestCase.java
@@ -51,7 +51,7 @@ public class TestCreateTestCase extends BaseTest {
 
         try {
             testCase = api.createTestCase("Sample Test Case " + System.currentTimeMillis(), testSuiteId, testProjectId,
-                    authorLogin, summary, null, preconditions, null, null, null, null, null, null);
+                    authorLogin, summary, null, preconditions, null, null, null, null, null, null, null);
         } catch (TestLinkAPIException e) {
             Assert.fail(e.getMessage(), e);
         }


### PR DESCRIPTION
Hi Bruno,

I'd like to use keywords via XML-RPC.
I think TestLink supports to add keywords via XML-RPC (but undocumented).

I wrote the code like below, I could create TestCase with the keywords "registered_keyword_A" and "registered_keyword_B" via API.

```java
        api = new TestLinkAPI(testlinkURL, devKey);
        TestCase testCase = api.createTestCase("TestCase", 15, project.getId(), "kondo", "summary", steps , "", importance,
                executionType, 0, null, false, ActionOnDuplicate.GENERATE_NEW,"registered_keyword_A, registered_keyword_B");
```

I added the parameter "keyword" to TestLinkAPI#createTestCase(). How do you think about it?
