### PR TITLE
Overloaded geTestCasesForTestPlan to take just the testPlan.

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -838,6 +838,17 @@ public class TestLinkAPI {
     }
 
     /**
+     * Retrieves Test Cases for Test Plans.
+     * 
+     * @param testPlanId
+     * @return Array of Test Cases of the Test Plan.
+     * @throws TestLinkAPIException
+     */
+    public TestCase[] getTestCasesForTestPlan(Integer testPlanId) throws TestLinkAPIException {
+        return this.testCaseService.getTestCasesForTestPlan(testPlanId);
+    }
+
+    /**
      * Get a test case ID by a test case Name
      * 
      * @param testCaseName


### PR DESCRIPTION
The TestLinkAPI lists other params as optional. So, it is easier this way
with just one param to be passed.