### PR TITLE
updated to set version on creating test case

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -104,9 +104,11 @@ class TestCaseService extends BaseService {
             Object response = this.executeXmlRpcCall(TestLinkMethods.CREATE_TEST_CASE.toString(), executionData);
             Object[] responseArray = Util.castToArray(response);
             Map<String, Object> responseMap = (Map<String, Object>) responseArray[0];
-
+            
+            Integer version = (Integer)((HashMap<String, Object>) responseMap.get("additionalInfo")).get("version_number");
             id = Util.getInteger(responseMap, TestLinkResponseParams.ID.toString());
             testCase.setId(id);
+            testCase.setVersion(version);
         } catch (XmlRpcException xmlrpcex) {
             throw new TestLinkAPIException("Error creating test plan: " + xmlrpcex.getMessage(), xmlrpcex);
         }


### PR DESCRIPTION
Problem is that test case object does not contain version nor version id:
testCase.getVersion() = null

So you cannot update custom fields in TestLink because it can't reach test case version.

It is overcomed by this commit in TestCaseService.java
In this way you can get version of test case after you create it.