### PR TITLE
Fixed assign test case execution task method. It requires a platform …

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -858,25 +858,31 @@ class TestCaseService extends BaseService {
     }
 
     /**
-     *
-     * @param testPlanId
-     * @param testCaseExternalId
-     * @param user
-     * @param buildName
-     * @throws TestLinkAPIException
-     */
-    protected void assignTestCaseExecutionTask(Integer testPlanId, String testCaseExternalId, String user,
-            String buildName) throws TestLinkAPIException {
-        try {
-            Map<String, Object> executionData = new HashMap<String, Object>();
-            executionData.put(TestLinkParams.TEST_PLAN_ID.toString(), testPlanId);
-            executionData.put(TestLinkParams.TEST_CASE_EXTERNAL_ID.toString(), testCaseExternalId);
-            executionData.put(TestLinkParams.USER.toString(), user);
-            executionData.put(TestLinkParams.BUILD_NAME.toString(), buildName);
-            this.executeXmlRpcCall(TestLinkMethods.ASSIGN_TEST_CASE_EXECUTION_TASK.toString(), executionData);
-        } catch (XmlRpcException xmlrpcex) {
-            throw new TestLinkAPIException("Error deleting execution: " + xmlrpcex.getMessage(), xmlrpcex);
-        }
-    }
+	 *
+	 * @param testPlanId
+	 * @param testCaseExternalId
+	 * @param user
+	 * @param buildName
+	 * @param buildId
+	 * @param platformName
+	 * @param platformID
+	 * @throws TestLinkAPIException
+	 */
+	protected void assignTestCaseExecutionTask(Integer testPlanId, String testCaseExternalId, String user,
+			Integer buildId, String buildName, Integer platformID, String platformName) throws TestLinkAPIException {
+		try {
+			Map<String, Object> executionData = new HashMap<String, Object>();
+			executionData.put(TestLinkParams.TEST_PLAN_ID.toString(), testPlanId);
+			executionData.put(TestLinkParams.TEST_CASE_EXTERNAL_ID.toString(), testCaseExternalId);
+			executionData.put(TestLinkParams.USER.toString(), user);
+			executionData.put(TestLinkParams.BUILD_NAME.toString(), buildName);
+			executionData.put(TestLinkParams.BUILD_ID.toString(), buildId);
+			executionData.put(TestLinkParams.PLATFORM_ID.toString(), platformID);
+			executionData.put(TestLinkParams.PLATFORM_NAME.toString(), platformName);
+			this.executeXmlRpcCall(TestLinkMethods.ASSIGN_TEST_CASE_EXECUTION_TASK.toString(), executionData);
+		} catch (XmlRpcException xmlrpcex) {
+			throw new TestLinkAPIException("Error deleting execution: " + xmlrpcex.getMessage(), xmlrpcex);
+		}
+	}
 
 }

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -575,12 +575,13 @@ class TestCaseService extends BaseService {
      * @param platformName
      * @param customFields
      * @param overwrite
+     * @param execduration
      * @return Response object of reportTCResult method
      * @throws TestLinkAPIException
      */
     protected ReportTCResultResponse reportTCResult(Integer testCaseId, Integer testCaseExternalId, Integer testPlanId,
             ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess, String bugId,
-            Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
+            Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite, Integer execduration)
             throws TestLinkAPIException {
         // TODO: Map<String, String> customFields =>
         // change for a list of custom fields. After implementing method

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -966,15 +966,16 @@ public class TestLinkAPI {
      * @param platformName platform name
      * @param customFields custom fields
      * @param overwrite flag to overwrite or not
+     * @param execduration Execution duration
      * @throws TestLinkAPIException if the service returns an error
      * @return report test case result server response
      */
     public ReportTCResultResponse reportTCResult(Integer testCaseId, Integer testCaseExternalId, Integer testPlanId,
             ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess, String bugId,
-            Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
+            Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite, Integer execduration)
             throws TestLinkAPIException {
         return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status, buildId,
-                buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite);
+                buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite, execduration);
     }
 
     /**
@@ -993,15 +994,16 @@ public class TestLinkAPI {
      * @param platformName platform name
      * @param customFields custom fields
      * @param overwrite flag to overwrite or not
+     * @param execduration Execution duration
      * @return response
      * @throws TestLinkAPIException if the service returns an error
      */
     public ReportTCResultResponse setTestCaseExecutionResult(Integer testCaseId, Integer testCaseExternalId,
             Integer testPlanId, ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess,
-            String bugId, Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
+            String bugId, Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite, Integer execduration)
             throws TestLinkAPIException {
         return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status, buildId,
-                buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite);
+                buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite, execduration);
     }
 
     /**

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -1121,20 +1121,24 @@ public class TestLinkAPI {
         return this.testCaseService.updateTestCaseCustomFieldDesignValue(testCaseId, versionNumber, testProjectId,
                 customFieldName, customFieldValue);
     }
-
+    
     /**
-     * Assign user to execute Test Case in Test Plan
-     *
+	 * Assign user to execute Test Case in Test Plan
+	 *
      * @param testPlanId test plan ID
      * @param testCaseExternalId test case external ID
-     * @param user user
-     * @param buildName build name
+	 * @param user
+	 * @param buildId
+	 * @param buildName build name
+	 * @param platformId
+	 * @param platformName
      * @throws TestLinkAPIException if the service returns an error
-     */
-    public void assignTestCaseExecutionTask(Integer testPlanId, String testCaseExternalId, String user,
-            String buildName) throws TestLinkAPIException {
-        this.testCaseService.assignTestCaseExecutionTask(testPlanId, testCaseExternalId, user, buildName);
-    }
+	 */
+	public void assignTestCaseExecutionTask(Integer testPlanId, String testCaseExternalId, String user, Integer buildId,
+			String buildName, Integer platformId, String platformName) throws TestLinkAPIException {
+		this.testCaseService.assignTestCaseExecutionTask(testPlanId, testCaseExternalId, user, buildId, buildName,
+				platformId, platformName);
+	}
 
     /* XX Requirements Specification operations XX */
 


### PR DESCRIPTION
Hi,

with TestLink Version 1.9.16 there was an error when trying to assign a test case execution with the API. Currently it seems to be necessary to add the platformId to the method call. I added the missing parameter and tested it successfully.

Regards
Dennis