### PR TITLE
Get test case attachments for test case version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,27 +1,6 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-<!-- 
-  The MIT License
-  
-  Copyright (c) 2010 Bruno P. Kinoshita
-  
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-  
-  The above copyright notice and this permission notice shall be included in
-  all copies or substantial portions of the Software.
-  
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-  THE SOFTWARE.
- -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>br.eti.kinoshita</groupId>
@@ -139,44 +118,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-site-plugin</artifactId>
                 <version>3.6</version>
-                <configuration>
-                    <reportPlugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-project-info-reports-plugin
-                            </artifactId>
-                            <version>2.9</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-checkstyle-plugin</artifactId>
-                            <version>2.17</version>
-                            <configuration>
-                                <configLocation>${checkstyle.rules}</configLocation>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-javadoc-plugin</artifactId>
-                            <version>2.10.4</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-changes-plugin</artifactId>
-                            <version>2.12.1</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-pmd-plugin</artifactId>
-                            <version>3.7</version>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-pmd-plugin</artifactId>
-                            <version>3.7</version>
-                        </plugin>
-                    </reportPlugins>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -191,13 +132,15 @@
                 </dependencies>
             </plugin>
             <plugin>
-                <groupId>org.owasp</groupId>
-                <artifactId>dependency-check-maven</artifactId>
-                <version>1.4.5</version>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>1.5</version>
                 <executions>
                     <execution>
+                        <id>sign-artifacts</id>
+                        <phase>deploy</phase>
                         <goals>
-                            <goal>check</goal>
+                            <goal>sign</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -221,6 +164,45 @@
             </extension>
         </extensions>
     </build>
+
+    <reporting>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-project-info-reports-plugin
+                </artifactId>
+                <version>2.9</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+                <version>2.17</version>
+                <configuration>
+                    <configLocation>${checkstyle.rules}</configLocation>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.10.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-changes-plugin</artifactId>
+                <version>2.12.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>3.7</version>
+            </plugin>
+        </plugins>
+    </reporting>
 
     <dependencies>
         <!-- Commons APIs -->
@@ -299,6 +281,18 @@
                                 <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.owasp</groupId>
+                        <artifactId>dependency-check-maven</artifactId>
+                        <version>1.4.5</version>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>check</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -23,6 +23,7 @@
  */
 package br.eti.kinoshita.testlinkjavaapi;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -51,6 +52,7 @@ import br.eti.kinoshita.testlinkjavaapi.model.CustomField;
 import br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCase;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCaseStep;
+import br.eti.kinoshita.testlinkjavaapi.model.TestCaseStepResult;
 import br.eti.kinoshita.testlinkjavaapi.util.TestLinkAPIException;
 import br.eti.kinoshita.testlinkjavaapi.util.Util;
 
@@ -566,6 +568,7 @@ class TestCaseService extends BaseService {
      * @param testCaseExternalId
      * @param testPlanId
      * @param status
+     * @param steps
      * @param buildId
      * @param buildName
      * @param notes
@@ -579,7 +582,7 @@ class TestCaseService extends BaseService {
      * @throws TestLinkAPIException
      */
     protected ReportTCResultResponse reportTCResult(Integer testCaseId, Integer testCaseExternalId, Integer testPlanId,
-            ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess, String bugId,
+            ExecutionStatus status, List<TestCaseStepResult> steps, Integer buildId, String buildName, String notes, Boolean guess, String bugId,
             Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
             throws TestLinkAPIException {
         // TODO: Map<String, String> customFields =>
@@ -594,6 +597,7 @@ class TestCaseService extends BaseService {
             executionData.put(TestLinkParams.TEST_CASE_EXTERNAL_ID.toString(), testCaseExternalId);
             executionData.put(TestLinkParams.TEST_PLAN_ID.toString(), testPlanId);
             executionData.put(TestLinkParams.STATUS.toString(), status.toString());
+            executionData.put(TestLinkParams.STEPS.toString(), steps);
             executionData.put(TestLinkParams.BUILD_ID.toString(), buildId);
             executionData.put(TestLinkParams.BUILD_NAME.toString(), buildName);
             executionData.put(TestLinkParams.NOTES.toString(), notes);

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -481,16 +481,18 @@ class TestCaseService extends BaseService {
     /**
      * @param testCaseId
      * @param testCaseExternalId
+     * @param testCaseVersion
      * @return
      * @throws TestLinkAPIException
      */
-    protected Attachment[] getTestCaseAttachments(Integer testCaseId, Integer testCaseExternalId)
+    protected Attachment[] getTestCaseAttachments(Integer testCaseId, Integer testCaseVersion, Integer testCaseExternalId)
             throws TestLinkAPIException {
         Attachment[] attachments = null;
 
         try {
             Map<String, Object> executionData = new HashMap<String, Object>();
             executionData.put(TestLinkParams.TEST_CASE_ID.toString(), testCaseId);
+            executionData.put(TestLinkParams.VERSION.toString(), testCaseVersion);
             executionData.put(TestLinkParams.TEST_CASE_EXTERNAL_ID.toString(), testCaseExternalId);
             Object response = this.executeXmlRpcCall(TestLinkMethods.GET_TEST_CASE_ATTACHMENTS.toString(),
                     executionData);

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -23,7 +23,6 @@
  */
 package br.eti.kinoshita.testlinkjavaapi;
 
-import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -942,12 +942,13 @@ public class TestLinkAPI {
      * 
      * @param testCaseId test case ID
      * @param testCaseExternalId test case external ID
+     * @param testCaseVersion test case version
      * @return Array of Attachments
      * @throws TestLinkAPIException if the service returns an error
      */
-    public Attachment[] getTestCaseAttachments(Integer testCaseId, Integer testCaseExternalId)
+    public Attachment[] getTestCaseAttachments(Integer testCaseId, Integer testCaseVersion,Integer testCaseExternalId)
             throws TestLinkAPIException {
-        return this.testCaseService.getTestCaseAttachments(testCaseId, testCaseExternalId);
+        return this.testCaseService.getTestCaseAttachments(testCaseId, testCaseVersion,testCaseExternalId);
     }
 
     /**

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -23,6 +23,7 @@
  */
 package br.eti.kinoshita.testlinkjavaapi;
 
+import java.lang.reflect.Array;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -58,6 +59,7 @@ import br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse;
 import br.eti.kinoshita.testlinkjavaapi.model.Requirement;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCase;
 import br.eti.kinoshita.testlinkjavaapi.model.TestCaseStep;
+import br.eti.kinoshita.testlinkjavaapi.model.TestCaseStepResult;
 import br.eti.kinoshita.testlinkjavaapi.model.TestPlan;
 import br.eti.kinoshita.testlinkjavaapi.model.TestProject;
 import br.eti.kinoshita.testlinkjavaapi.model.TestSuite;
@@ -984,6 +986,7 @@ public class TestLinkAPI {
      * @param testCaseExternalId test case external ID
      * @param testPlanId test plan ID
      * @param status status
+     * @param steps test steps results
      * @param buildId build ID
      * @param buildName build name
      * @param notes notes
@@ -997,10 +1000,10 @@ public class TestLinkAPI {
      * @return report test case result server response
      */
     public ReportTCResultResponse reportTCResult(Integer testCaseId, Integer testCaseExternalId, Integer testPlanId,
-            ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess, String bugId,
+            ExecutionStatus status, List<TestCaseStepResult> steps,Integer buildId, String buildName, String notes, Boolean guess, String bugId,
             Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
             throws TestLinkAPIException {
-        return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status, buildId,
+        return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status,steps, buildId,
                 buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite);
     }
 
@@ -1011,6 +1014,7 @@ public class TestLinkAPI {
      * @param testCaseExternalId test case external ID
      * @param testPlanId test plan ID
      * @param status status
+     * * @param steps test steps results
      * @param buildId build ID
      * @param buildName build name
      * @param notes notes
@@ -1024,10 +1028,10 @@ public class TestLinkAPI {
      * @throws TestLinkAPIException if the service returns an error
      */
     public ReportTCResultResponse setTestCaseExecutionResult(Integer testCaseId, Integer testCaseExternalId,
-            Integer testPlanId, ExecutionStatus status, Integer buildId, String buildName, String notes, Boolean guess,
+            Integer testPlanId, ExecutionStatus status, List<TestCaseStepResult> steps,Integer buildId, String buildName, String notes, Boolean guess,
             String bugId, Integer platformId, String platformName, Map<String, String> customFields, Boolean overwrite)
             throws TestLinkAPIException {
-        return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status, buildId,
+        return this.testCaseService.reportTCResult(testCaseId, testCaseExternalId, testPlanId, status,steps, buildId,
                 buildName, notes, guess, bugId, platformId, platformName, customFields, overwrite);
     }
 

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -23,7 +23,6 @@
  */
 package br.eti.kinoshita.testlinkjavaapi;
 
-import java.lang.reflect.Array;
 import java.net.URL;
 import java.util.List;
 import java.util.Map;
@@ -1014,7 +1013,7 @@ public class TestLinkAPI {
      * @param testCaseExternalId test case external ID
      * @param testPlanId test plan ID
      * @param status status
-     * * @param steps test steps results
+     * @param steps test steps results
      * @param buildId build ID
      * @param buildName build name
      * @param notes notes

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/model/TestCaseStepResult.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/model/TestCaseStepResult.java
@@ -1,0 +1,117 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010 Bruno P. Kinoshita http://www.kinoshita.eti.br
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package br.eti.kinoshita.testlinkjavaapi.model;
+
+import java.io.Serializable;
+
+import br.eti.kinoshita.testlinkjavaapi.constants.ExecutionStatus;
+import br.eti.kinoshita.testlinkjavaapi.constants.ExecutionType;
+
+/**
+ * @author Kai Adelmann kai.adelmann@gmail.com
+ * @since 1.9.18
+ */
+public class TestCaseStepResult implements Serializable {
+
+    private static final long serialVersionUID = -2964599381390137202L;
+
+    private Integer step_number;
+    private ExecutionStatus result;
+    private String notes;
+
+    /**
+     * 
+     */
+    public TestCaseStepResult() {
+        super();
+    }
+
+    /**
+     * @param number number of the test step
+     * @param result ExecutionStatus
+     * @param notes execution notes for the test step
+     */
+    public TestCaseStepResult(Integer number, ExecutionStatus result, String notes,
+            Boolean active, ExecutionType executionType) {
+        super();
+        this.step_number = number;
+        this.result = result;
+        this.notes = notes;
+    }
+
+
+    /**
+     * @return the number
+     */
+    public Integer getNumber() {
+        return step_number;
+    }
+
+    /**
+     * @param number the number to set
+     */
+    public void setNumber(Integer number) {
+        this.step_number = number;
+    }
+
+    /**
+     * @return the result
+     */
+    public ExecutionStatus getResult() {
+        return result;
+    }
+
+    /**
+     * @param result the result to set
+     */
+    public void setResult(ExecutionStatus result) {
+        this.result = result;
+    }
+
+    /**
+     * @return the notes
+     */
+    public String getNotes() {
+        return notes;
+    }
+
+    /**
+     * @param notes the notes to set
+     */
+    public void setNotes(String notes) {
+        this.notes = notes;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "TestCaseStepResult [number=" + step_number
+                + ", result=" + result + ", notes=" + notes + "]";
+    }
+
+}

--- a/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestGetTestCaseAttachments.java
+++ b/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestGetTestCaseAttachments.java
@@ -49,7 +49,7 @@ public class TestGetTestCaseAttachments extends BaseTest {
         Attachment[] attachments = null;
 
         try {
-            attachments = this.api.getTestCaseAttachments(testCaseId, null);
+            attachments = this.api.getTestCaseAttachments(testCaseId, null,null);
         } catch (TestLinkAPIException e) {
             Assert.fail(e.getMessage(), e);
         }

--- a/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestReportTCStepResults.java
+++ b/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestReportTCStepResults.java
@@ -23,6 +23,9 @@
  */
 package br.eti.kinoshita.testlinkjavaapi.testcase;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,55 +33,46 @@ import org.testng.annotations.Test;
 import br.eti.kinoshita.testlinkjavaapi.BaseTest;
 import br.eti.kinoshita.testlinkjavaapi.constants.ExecutionStatus;
 import br.eti.kinoshita.testlinkjavaapi.model.ReportTCResultResponse;
+import br.eti.kinoshita.testlinkjavaapi.model.TestCaseStepResult;
 import br.eti.kinoshita.testlinkjavaapi.util.TestLinkAPIException;
 
 /**
  * <ul>
- * <li>20101130 - BUGID: 3123764 - kinow - reportTCresult not returning execution data</li>
+ * <li>20181017 - Issue #100: reportTCresult missing Parameter for setting test steps result</li>
  * </ul>
  *
- * @author Bruno P. Kinoshita - http://www.kinoshita.eti.br
+ * @author Kai Adelmann - kai.adelmann@gmail.com
  */
-public class TestReportTCResult extends BaseTest {
+public class TestReportTCStepResults extends BaseTest {
 
     @DataProvider(name = "buildData")
     public Object[][] createData() {
-        return new Object[][] { { 4, 10, 1, "Sample build", "Build notes.", 2, "Post" } };
+        List<TestCaseStepResult> steps=new ArrayList<TestCaseStepResult>();
+        TestCaseStepResult step1= new TestCaseStepResult();
+        step1.setNumber(1);
+        step1.setResult(ExecutionStatus.PASSED);
+        step1.setNotes("Keine besonderen Vorkommnisse");
+        TestCaseStepResult step2= new TestCaseStepResult();
+        step2.setNumber(2);
+        step2.setResult(ExecutionStatus.FAILED);
+        step2.setNotes("Fehler!!!");
+        steps.add(step1);
+        steps.add(step2);
+        
+        return new Object[][] { { 4, 10, 1, "Sample build", "Build notes.", steps, 2, "Post" } };
     }
 
     @Test(dataProvider = "buildData")
     public void testReportTCResult(Integer testCaseId, Integer testPlanId, Integer buildId, String buildName,
-            String notes, Integer platformId, String platformName) {
+            String notes, List<TestCaseStepResult> steps, Integer platformId, String platformName) {
         this.loadXMLRPCMockData("tl.reportTCResult.xml");
 
         ReportTCResultResponse response = null;
         try {
-            response = this.api.reportTCResult(testCaseId, null, testPlanId, ExecutionStatus.FAILED, null, buildId, buildName,
+            response = this.api.reportTCResult(testCaseId, null, testPlanId, ExecutionStatus.FAILED, steps, buildId, buildName,
                     notes, true, null, platformId, platformName, null, // TODO:
                                                                        // Test
                                                                        // custom
-                    // fields!
-                    true);
-        } catch (TestLinkAPIException e) {
-            Assert.fail(e.getMessage(), e);
-        }
-
-        Assert.assertNotNull(response);
-
-        Assert.assertTrue(response.getExecutionId() > 0);
-    }
-
-    @Test(dataProvider = "buildData")
-    public void testSetTestCaseExecutionResult(Integer testCaseId, Integer testPlanId, Integer buildId,
-            String buildName, String notes, Integer platformId, String platformName) {
-        this.loadXMLRPCMockData("tl.reportTCResult.xml");
-
-        ReportTCResultResponse response = null;
-        try {
-            response = this.api.setTestCaseExecutionResult(testCaseId, null, testPlanId, ExecutionStatus.PASSED, null,
-                    buildId, buildName, notes, true, null, platformId, platformName, null, // TODO:
-                    // Test
-                    // custom
                     // fields!
                     true);
         } catch (TestLinkAPIException e) {


### PR DESCRIPTION
Added parameter for setting specific version of the testcase to get
attachments for (as introduced in TestLink 1.9.18)

Seems I can't get rid of the merged things from the last pull request (and I can't tell why...). Hope you're able to sort it out anyway - Sorry for the extra work...

Best
Kai