### PR TITLE
getTestCaseCustomFieldExecutionValue is outdated #113

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -6,6 +6,12 @@
     </properties>
     <body>
         <release version="" date="" description="">
+            <action dev="ranamansoor" type="fix" issue="113">
+                Issue #113: Added testplan parameter into getTestCaseCustomFieldExecutionValue
+            </action>
+            <action dev="ranamansoor" type="add" issue="91">
+                Issue #91: Added build is_active and is_open options.
+            </action>
             <action dev="kinow" type="fix" issue="90">
                 Issue #90: Replace httpclient
             </action>

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -715,6 +715,7 @@ class TestCaseService extends BaseService {
      * @param testCaseId
      * @param testCaseExternalId
      * @param versionNumber
+     * @param testPlanId
      * @param testProjectId
      * @param customFieldName
      * @param details
@@ -722,7 +723,7 @@ class TestCaseService extends BaseService {
      * @throws TestLinkAPIException
      */
     protected CustomField getTestCaseCustomFieldExecutionValue(Integer testCaseId, Integer testCaseExternalId,
-            Integer versionNumber, Integer executionId, Integer testProjectId, String customFieldName,
+            Integer versionNumber, Integer executionId, Integer testPlanId, Integer testProjectId, String customFieldName,
             ResponseDetails details) throws TestLinkAPIException {
         CustomField customField = null;
 
@@ -731,6 +732,7 @@ class TestCaseService extends BaseService {
             executionData.put(TestLinkParams.TEST_CASE_ID.toString(), testCaseId);
             executionData.put(TestLinkParams.TEST_CASE_EXTERNAL_ID.toString(), testCaseExternalId);
             executionData.put(TestLinkParams.VERSION.toString(), versionNumber);
+            executionData.put(TestLinkParams.TEST_PLAN_ID.toString(),testPlanId);
             executionData.put(TestLinkParams.TEST_PROJECT_ID.toString(), testProjectId);
             executionData.put(TestLinkParams.CUSTOM_FIELD_NAME.toString(), customFieldName);
             executionData.put(TestLinkParams.DETAILS.toString(), Util.getStringValueOrNull(details));
@@ -758,9 +760,8 @@ class TestCaseService extends BaseService {
     /**
      * Gets list of keywords for a given Test case
      * 
+     * @param testProjectId
      * @param testCaseId
-     * @param testCaseExternalId
-     * @param version
      * @return
      * @throws TestLinkAPIException
      */

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -1096,6 +1096,7 @@ public class TestLinkAPI {
      * @param testCaseExternalId test case external ID
      * @param versionNumber version number
      * @param executionId execution ID
+     * @param testPlanID
      * @param testProjectId test project ID
      * @param customFieldName custom field name
      * @param details details
@@ -1103,10 +1104,10 @@ public class TestLinkAPI {
      * @throws TestLinkAPIException if the service returns an error
      */
     public CustomField getTestCaseCustomFieldExecutionValue(Integer testCaseId, Integer testCaseExternalId,
-            Integer versionNumber, Integer executionId, Integer testProjectId, String customFieldName,
+            Integer versionNumber, Integer executionId, Integer testPlanID, Integer testProjectId, String customFieldName,
             ResponseDetails details) throws TestLinkAPIException {
         return this.testCaseService.getTestCaseCustomFieldExecutionValue(testCaseId, testCaseExternalId, versionNumber,
-                executionId, testProjectId, customFieldName, details);
+                executionId, testPlanID, testProjectId, customFieldName, details);
     }
 
     /**

--- a/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestGetTestCaseCustomFieldExecutionValue.java
+++ b/src/test/java/br/eti/kinoshita/testlinkjavaapi/testcase/TestGetTestCaseCustomFieldExecutionValue.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2010 Bruno P. Kinoshita http://www.kinoshita.eti.br
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package br.eti.kinoshita.testlinkjavaapi.testcase;
+
+import br.eti.kinoshita.testlinkjavaapi.BaseTest;
+import br.eti.kinoshita.testlinkjavaapi.constants.ResponseDetails;
+import br.eti.kinoshita.testlinkjavaapi.model.CustomField;
+import br.eti.kinoshita.testlinkjavaapi.util.TestLinkAPIException;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * @author Rana Mansoor
+ */
+public class TestGetTestCaseCustomFieldExecutionValue extends BaseTest {
+
+    @DataProvider(name = "testCaseWithCustomFieldExecution")
+    public Object[][] createData() {
+        return new Object[][]{{4, 1, 1, 2, 3, "SampleCustomField"}, {6, 1, 1, 2, 3, "SampleCustomField"}};
+    }
+
+    @Test(dataProvider = "testCaseWithCustomFieldExecution")
+    public void testGetTestCaseCustomFieldExecutionValueFull(Integer testCaseId, Integer versionNumber, Integer executionId,
+                                                             Integer testPlanId, Integer testProjectId, String customFieldName) {
+        this.loadXMLRPCMockData("tl.getTestCaseCustomFieldExecutionValue.xml");
+
+        CustomField customField = null;
+        try {
+            customField = this.api.getTestCaseCustomFieldExecutionValue(testCaseId, null, versionNumber,
+                    executionId, testPlanId, testProjectId, customFieldName, ResponseDetails.FULL);
+
+
+        } catch (TestLinkAPIException e) {
+            Assert.fail(e.getMessage(), e);
+        }
+        Assert.assertNotNull(customField);
+
+        Assert.assertNotNull(customField.getValue());
+
+        Assert.assertTrue(customField.getValue().length() > 0);
+    }
+
+    @Test(dataProvider = "testCaseWithCustomFieldExecution")
+    public void testGetTestCaseCustomFieldExecutionValueSimple(Integer testCaseId, Integer versionNumber, Integer executionId,
+                                                               Integer testPlanId, Integer testProjectId, String customFieldName) {
+        this.loadXMLRPCMockData("tl.getTestCaseCustomFieldExecutionValue.xml");
+
+        CustomField customField = null;
+        try {
+            customField = this.api.getTestCaseCustomFieldExecutionValue(testCaseId, null, versionNumber,
+                    executionId, testPlanId, testProjectId, customFieldName, ResponseDetails.SIMPLE);
+        } catch (TestLinkAPIException e) {
+            Assert.fail(e.getMessage(), e);
+        }
+        Assert.assertNotNull(customField);
+
+        Assert.assertNotNull(customField.getValue());
+
+        Assert.assertTrue(customField.getValue().length() > 0);
+    }
+
+    @Test(dataProvider = "testCaseWithCustomFieldExecution")
+    public void testGetTestCaseCustomFieldExecutionValueValue(Integer testCaseId, Integer versionNumber, Integer executionId,
+                                                              Integer testPlanId, Integer testProjectId, String customFieldName) {
+        this.loadXMLRPCMockData("tl.getTestCaseCustomFieldExecutionValue.xml");
+
+        CustomField customField = null;
+        try {
+            customField = this.api.getTestCaseCustomFieldExecutionValue(testCaseId, null, versionNumber, executionId,
+                    testPlanId, testProjectId, customFieldName, ResponseDetails.VALUE);
+        } catch (TestLinkAPIException e) {
+            Assert.fail(e.getMessage(), e);
+        }
+        Assert.assertNotNull(customField);
+
+        Assert.assertNotNull(customField.getValue());
+
+        Assert.assertTrue(customField.getValue().length() > 0);
+    }
+
+}

--- a/src/test/resources/br/eti/kinoshita/testlinkjavaapi/testdata/tl.getTestCaseCustomFieldExecutionValue.xml
+++ b/src/test/resources/br/eti/kinoshita/testlinkjavaapi/testdata/tl.getTestCaseCustomFieldExecutionValue.xml
@@ -1,0 +1,9 @@
+<methodResponse>
+    <params>
+        <param>
+            <value>
+                <string>abc</string>
+            </value>
+        </param>
+    </params>
+</methodResponse>


### PR DESCRIPTION
In this build following updates are included

1. Changes.xml updated 
2. Fixed getTestCaseCustomFieldExecutionValue 

- Added testplan_id param into TestCaseService.java
- Added testplan_id param into TestLinkAPI.java
- Create java file for testcase custom field execution (TestGetTestCaseCustomFieldExecutionValue.java)
- Create xml file for testcase custom field execution value (tl.getTestCaseCustomFieldExecutionValue.xml)

Regards,
Rana Mansoor