### PR TITLE
Add test case version for uploadTestCaseAttachment methods

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -6,6 +6,9 @@
     </properties>
     <body>
         <release version="1.9.?" date="2021-??-??" description="">
+            <action dev="leightjohnson93" type="fix">
+                Add test case version for uploadTestCaseAttachment method
+            </action>
             <action dev="kinow" type="update">
                  Bump commons-io from 2.6 to 2.7 #137.
             </action>

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -441,10 +441,11 @@ class TestCaseService extends BaseService {
      * @param fileName
      * @param fileType
      * @param content
+     * @param version
      * @return
      */
     protected Attachment uploadTestCaseAttachment(Integer testCaseId, String title, String description, String fileName,
-            String fileType, String content) throws TestLinkAPIException {
+            String fileType, String content, int version) throws TestLinkAPIException {
         Attachment attachment;
 
         Integer id = 0;
@@ -454,6 +455,7 @@ class TestCaseService extends BaseService {
 
         try {
             Map<String, Object> executionData = Util.getTestCaseAttachmentMap(attachment);
+            executionData.put(TestLinkParams.VERSION.toString(), version);
             Object response = this.executeXmlRpcCall(TestLinkMethods.UPLOAD_TEST_CASE_ATTACHMENT.toString(),
                     executionData);
             Map<String, Object> responseMap = Util.castToMap(response);

--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestLinkAPI.java
@@ -959,13 +959,14 @@ public class TestLinkAPI {
      * @param fileName file name
      * @param fileType file type
      * @param content content
+     * @param version test case version
      * @return Attachment.
      * @throws TestLinkAPIException if the service returns an error
      */
     public Attachment uploadTestCaseAttachment(Integer testCaseId, String title, String description, String fileName,
-            String fileType, String content) throws TestLinkAPIException {
+            String fileType, String content, int version) throws TestLinkAPIException {
         return this.testCaseService.uploadTestCaseAttachment(testCaseId, title, description, fileName, fileType,
-                content);
+                content, version);
     }
 
     /**

--- a/src/test/java/br/eti/kinoshita/testlinkjavaapi/upload/TestUploadTestCaseAttachment.java
+++ b/src/test/java/br/eti/kinoshita/testlinkjavaapi/upload/TestUploadTestCaseAttachment.java
@@ -40,18 +40,18 @@ public class TestUploadTestCaseAttachment extends BaseTest {
     @DataProvider(name = "testCaseAttachmentData")
     public Object[][] createData() {
         return new Object[][] { { 8, "Attachment title", "Attachment description", "attachmentFileName.txt",
-                "text/plain", "QnJ1bm8=" } };
+                "text/plain", "QnJ1bm8=", 1 } };
     }
 
     @Test(dataProvider = "testCaseAttachmentData")
     public void testUploadTestCaseAttachment(Integer testCaseId, String title, String description, String fileName,
-            String fileType, String content) {
+            String fileType, String content, int version) {
         this.loadXMLRPCMockData("tl.uploadTestCaseAttachment.xml");
 
         Attachment attachment = null;
 
         try {
-            attachment = this.api.uploadTestCaseAttachment(testCaseId, title, description, fileName, fileType, content);
+            attachment = this.api.uploadTestCaseAttachment(testCaseId, title, description, fileName, fileType, content, version);
         } catch (TestLinkAPIException e) {
             Assert.fail(e.getMessage(), e);
         }


### PR DESCRIPTION
`uploadTestCaseAttachment` was returning error: "Parameter version required" from xmlrpc.  This PR allows the user pass in a test case version.


- [X] unit tests included
- [X ] entry to changes.xml
- [ X] removed any @author tag
- [ X] avoided adding multiple commits for formatting/etc. The less commits the better, when possible
- [ X] modified only the necessary for the change, avoiding changing formatting, removing empty lines, etc
- [ ] the code refers to a bug reported, or to enhancements to support the PHP code (no extra code is added in the Java API for simplicity)
