### PR TITLE
Updated logger for assignTestCaseExecutionTask exception

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestCaseService.java
@@ -882,7 +882,7 @@ class TestCaseService extends BaseService {
             executionData.put(TestLinkParams.BUILD_NAME.toString(), buildName);
             this.executeXmlRpcCall(TestLinkMethods.ASSIGN_TEST_CASE_EXECUTION_TASK.toString(), executionData);
         } catch (XmlRpcException xmlrpcex) {
-            throw new TestLinkAPIException("Error deleting execution: " + xmlrpcex.getMessage(), xmlrpcex);
+            throw new TestLinkAPIException("Error assigning test case execution task: " + xmlrpcex.getMessage(), xmlrpcex);
         }
     }
 


### PR DESCRIPTION
Updated logger message for method assignTestCaseExecutionTask
The existing logger message was copied from another method in the same class - deleteExecution
