### PR TITLE
fix call executeXmlRpcCall in methods removePlatformFromTestPlan in class TestPlanService

### DIFF
--- a/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestPlanService.java
+++ b/src/main/java/br/eti/kinoshita/testlinkjavaapi/TestPlanService.java
@@ -205,7 +205,7 @@ class TestPlanService extends BaseService {
             executionData.put(TestLinkParams.TEST_PROJECT_ID.toString(), testProjectId);
             executionData.put(TestLinkParams.TEST_PLAN_ID.toString(), testPlanId);
             executionData.put(TestLinkParams.PLATFORM_NAME.toString(), platformName);
-            Object response = this.executeXmlRpcCall(TestLinkMethods.ADD_PLATFORM_TO_TEST_PLAN.toString(),
+            Object response = this.executeXmlRpcCall(TestLinkMethods.REMOVE_PLATFORM_FROM_TEST_PLAN.toString(),
                     executionData);
             return Util.castToMap(response);
         } catch (XmlRpcException xmlrpcex) {


### PR DESCRIPTION
Hi Mr @kinow 

In Class **TestPlanService** have methods name `removePlatformFromTestPlan`, but in Object Response `executeXmlRpcCall`, the methods call `TestLinkMethods.ADD_PLATFORM_TO_TEST_PLAN` should call `TestLinkMethods.REMOVE_PLATFORM_FROM_TEST_PLAN`. 

i found this bug when i doing implement your method `removePlatformFromTestPlan` but my platform wont remove and always in Assign Platforms in testlink, when i execute the method should my platform in Available Plaforms.

Regards